### PR TITLE
Update dependencies (closes #2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ edition     = "2018"
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
-aes = "0.1.0"
-crypto-mac = "0.6"
-block-modes = "0.1"
+aes = "0.3"
+crypto-mac = "0.7"
+block-modes = "0.2"
 byteorder = { version = "1.2", default-features = false }
-cmac = "0.1"
-dbl = "0.1"
-pmac = "0.1"
+cmac = "0.2"
+dbl = "0.2"
+pmac = "0.2"
 ring = { version = "0.13", optional = true }
-subtle = { version = "0.3", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "0.4", default-features = false, features = ["linux-backport", "windows"] }
 
 [dev-dependencies]
@@ -35,7 +35,6 @@ data-encoding = "2.0"
 serde_json = "1"
 
 [features]
-aes-soft = ["aes/force_soft"]
 alloc = []
 bench = ["ring"]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ You can configure your `~/.cargo/config` to always pass these flags:
 rustflags = ["-Ctarget-feature=+aes"]
 ```
 
-To force usage of a software implementation of AES, use the `aes-soft`
-feature flag which enables usage on other CPU architectures.
-
 ## Help and Discussion
 
 Have questions? Want to suggest a feature or change?

--- a/src/s2v.rs
+++ b/src/s2v.rs
@@ -19,7 +19,7 @@ where
     T: AsRef<[u8]>,
 {
     mac.input(&GenericArray::<u8, M::OutputSize>::default());
-    let mut state = mac.result().code();
+    let mut state = mac.result_reset().code();
 
     for (i, header) in headers.into_iter().enumerate() {
         if i >= MAX_ASSOCIATED_DATA {
@@ -28,7 +28,7 @@ where
 
         state = state.dbl();
         mac.input(header.as_ref());
-        let code = mac.result().code();
+        let code = mac.result_reset().code();
         xor_in_place(&mut state, &code);
     }
 
@@ -46,7 +46,7 @@ where
     };
 
     mac.input(state.as_ref());
-    mac.result().code()
+    mac.result_reset().code()
 }
 
 /// XOR the second argument into the first in-place. Slices do not have to be


### PR DESCRIPTION
This is the same idea as #2, but should hopefully pass rustfmt now that the rest of the codebase is updated to the 2018 edition.